### PR TITLE
Replace --arangodb.endpoint with environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,13 @@ in a format compatible with prometheus.
 ## Usage
 
 To use the ArangoDB Exporter, run the following:
+```
 
+export DB_URL="http://arangodb_username:arangodb_pass@0.0.0.0:8529"
+
+```
 ```bash
 arangodb-exporter \
-    --arangodb.endpoint=http://<your-database-host>:8529 \
     --arangodb.jwtsecret=<your-jwt-secret> \
     --ssl.keyfile=<your-optional-ssl-keyfile>
 ```

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	_ "net/http/pprof"
 	"strings"
 	"time"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -62,7 +63,6 @@ func init() {
 	f.StringVar(&serverOptions.Address, "server.address", ":9101", "Address the exporter will listen on (IP:port)")
 	f.StringVar(&serverOptions.TLSKeyfile, "ssl.keyfile", "", "File containing TLS certificate used for the metrics server. Format equal to ArangoDB keyfiles")
 
-	f.StringVar(&arangodbOptions.endpoint, "arangodb.endpoint", "http://127.0.0.1:8529", "Endpoint used to reach the ArangoDB server")
 	f.StringVar(&arangodbOptions.jwtSecret, "arangodb.jwtsecret", "", "JWT Secret used for authentication with ArangoDB server")
 	f.StringVar(&arangodbOptions.jwtFile, "arangodb.jwt-file", "", "File containing the JWT for authentication with ArangoDB server")
 	f.DurationVar(&arangodbOptions.timeout, "arangodb.timeout", time.Second*15, "Timeout of statistics requests for ArangoDB")
@@ -78,6 +78,9 @@ func cmdMainRun(cmd *cobra.Command, args []string) {
 	log.Infoln(fmt.Sprintf("Starting arangodb-exporter %s, build %s", projectVersion, projectBuild))
 
 	var token string
+	var conn string
+        conn = os.Getenv("DB_URL")
+	
 	if arangodbOptions.jwtFile != "" {
 		data, err := ioutil.ReadFile(arangodbOptions.jwtFile)
 		if err != nil {
@@ -92,7 +95,7 @@ func cmdMainRun(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	exporter, err := NewExporter(arangodbOptions.endpoint, token, false, arangodbOptions.timeout)
+	exporter, err := NewExporter(conn, token, false, arangodbOptions.timeout)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@
 // Copyright holder is ArangoDB GmbH, Cologne, Germany
 //
 // Author Ewout Prangsma
-//
+// Edited by Ayman Shorman
 
 package main
 


### PR DESCRIPTION
The current process is exposing the username and password to the system and the solution i found is to set the connection string (arangodb.endpoint) in an environment variable and it worked!

Ayman Shorman