### PR TITLE
Metrics V2 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In this mode metrics are calculated on ArangoDB Exporter side
 
 Expose ArangoDB metrics for ArangoDB >= 3.6.0
 
-In this mode metrics provided by ArangoDB `_admin/metrics` are exposed on Exporter port.
+In this mode metrics provided by ArangoDB `_admin/metrics/v2` are exposed on Exporter port.
 
 ## Running in Docker
 

--- a/passthru.go
+++ b/passthru.go
@@ -45,7 +45,7 @@ func newHttpClientFactory(arangodbEndpoint string, auth Authentication, sslVerif
 	return func() (*http.Client, *http.Request, error) {
 		transport := &http.Transport{}
 
-		req, err := http.NewRequest("GET", fmt.Sprintf("%s/_admin/metrics", arangodbEndpoint), nil)
+		req, err := http.NewRequest("GET", fmt.Sprintf("%s/_admin/metrics/v2", arangodbEndpoint), nil)
 		if err != nil {
 			return nil, nil, maskAny(err)
 		}


### PR DESCRIPTION
ArangoDB >= 3.8 uses /_admin/metrics/v2 instead of /_admin/metrics as
endpoint.

This PR shows which changes would be necessary to enable this in the
exporter. Maybe we can publish this as a separate version such that one
can choose to use the newer API for newer versions of ArangoDB.

Alternatively, we could make it automatic to detect the version...
